### PR TITLE
Fix repo link in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Justin Moore <me@justinm.one>"]
 
 description = "Safe and lockless fixed-size memory allocator for `no_std` systems"
 keywords = ["no_std", "allocator", "kernel", "slab", "lock-free"]
-repository = "https://github.com/DrChat/buddyalloc"
+repository = "https://github.com/DrChat/slaballoc"
 license = "Apache-2.0/MIT"
 readme = "README.md"
 


### PR DESCRIPTION
The repository link in `Cargo.toml` points to the `buddyalloc` repo, so if you click the repo link from the [docs.rs page](https://docs.rs/slaballoc/latest/slaballoc/) you end up at https://github.com/DrChat/buddyalloc. Which is fairly confusing if you're not paying close enough attention (like I wasn't 🙂).

This updates the link in `Cargo.toml` to the `slaballoc` repo.